### PR TITLE
fix #12 MToon shader rimColor

### DIFF
--- a/src/materials/VRMShaderMaterial.ts
+++ b/src/materials/VRMShaderMaterial.ts
@@ -122,6 +122,12 @@ const convertParameters = new Map<string, (material: VRMShaderMaterial) => void>
   [
     'VRM/MToon',
     material => {
+      if (!material.uniforms.t_SphereAdd) {
+        material.uniforms.t_SphereAdd = {
+          value: new THREE.DataTexture(new Uint8Array(3), 1, 1, THREE.RGBFormat),
+        };
+      }
+
       material.uniforms.shininess = { value: 0.0 };
 
       switch (material.userData.RenderType) {


### PR DESCRIPTION
MToon シェーダーで描画がおかしくなるのは mtoon_frag.glsl の下記の部分で t_SphereAdd がない場合に起こることがわかりました。
```glsl
  vec4 rimColor = texture2D(t_SphereAdd, rimUv);
```
これはVRMを生成するときにMatCapがNoneになってた場合に起こるので、その場合にダミーのテクスチャを入れることで不正確な描画を防ぐようにしました。