### PR TITLE
add GLTFLoader into webpack externals

### DIFF
--- a/examples/script/index.html
+++ b/examples/script/index.html
@@ -21,6 +21,7 @@
 
   <body>
     <script src="../../node_modules/three/build/three.min.js"></script>
+    <script src="../../node_modules/three/examples/js/loaders/GLTFLoader.js"></script>
     <script src="../../node_modules/three/examples/js/controls/OrbitControls.js"></script>
     <script src="../../lib/index.js"></script>
     <script>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "yarn start:module",
     "start:module": "webpack-dev-server --config webpack.examples.config.js",
     "start:script": "http-server ./",
-    "build": "rm -rf lib && webpack && echo 'Object.assign(THREE,__three_vrm__);' >> lib/index.js && tsc --emitDeclarationOnly",
+    "build": "rm -rf lib && webpack && tsc --emitDeclarationOnly",
     "build:examples": "rm -rf dist && webpack --config webpack.examples.config.js",
     "gh-pages": "yarn build:examples && gh-pages -d dist",
     "test": "yarn lint",

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -1,0 +1,3 @@
+import * as __three_vrm__ from '.';
+// @ts-ignore
+Object.assign(THREE, __three_vrm__);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ const base = {
 module.exports = [
   base,
   webpackMerge(base, {
+    entry: path.resolve(__dirname, 'src', 'assign.ts'),
     output: {
       filename: 'index.js',
       library: '__three_vrm__',
@@ -48,7 +49,7 @@ module.exports = [
     },
     externals: {
       three: 'THREE',
-      'three/examples/jsm/loaders/GLTFLoader': 'THREE.GLTFLoader'
+      'three/examples/jsm/loaders/GLTFLoader': 'THREE'
     },
   }),
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,7 @@ const base = {
   },
   externals: {
     three: 'three',
+    'three/examples/jsm/loaders/GLTFLoader': 'three/examples/jsm/loaders/GLTFLoader'
   },
 };
 
@@ -47,6 +48,7 @@ module.exports = [
     },
     externals: {
       three: 'THREE',
+      'three/examples/jsm/loaders/GLTFLoader': 'THREE.GLTFLoader'
     },
   }),
 ];


### PR DESCRIPTION
Because GLTFLoader is not included in externals, three.js has been accidentally embedded in three-vrm. This patch fix it.